### PR TITLE
Prioritize clients by app name

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -921,6 +921,25 @@ Set the pool mode to be used for all connections from this user. If not set, the
 database or default pool_mode is used.
 
 
+Section [priorities]
+====================
+
+This contains key=value pairs where key will be taken as an application_name
+and value as a priority between 0 and 65535. When an application connects, the
+connection is assigned a priority. When there are not enough database connections
+to service the client connections, available space will be given out in strict
+priority order, larger priorities first.
+
+
+Caveats:
+--------
+
+1) The key (an application name) must be an exact match for the application_name
+variable that the client application sends to the server.
+
+1) Priorities are not weights, they are ordering, so starvation is possible.
+
+
 Include directive
 =================
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -252,6 +252,16 @@ another pool, because the server connection for the first pool is still open.
 Once the server connection closes (due to idle timeout), a new server connection
 will immediately be opened for the waiting pool.
 
+default_priority
+----------------
+
+The priority assigned to client connections that do not have a configured priority
+in the [priorities] section, or that have no app_name. It must be in the range of
+1-65535. Setting this larger than 1 allows configurations to de-prioritize matching
+applications below the default.
+
+Default: 10
+
 server_round_robin
 ------------------
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -383,8 +383,8 @@ struct PgSocket {
 /* takeover_clean_socket() needs to clean those up */
 
 struct SocketPriority {
-	struct AANode tree_node;	/* used to attach user to tree */
-	char *name;		/* The application_name to be assigned priority. */
+	struct List list_node;	/* used to attach user to tree */
+	char *prefix_matcher;	/* The application_name prefix matcher. */
 	uint16_t priority;	/* The priority value of sockets matching name. */
 };
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -388,8 +388,6 @@ struct SocketPriority {
 	uint16_t priority;	/* The priority value of sockets matching name. */
 };
 
-#define DEFAULT_SOCKET_PRIORITY 1
-
 /* where the salt is temporarily stored */
 #define tmp_login_salt  cancel_key
 
@@ -414,6 +412,7 @@ extern int cf_res_pool_size;
 extern usec_t cf_res_pool_timeout;
 extern int cf_max_db_connections;
 extern int cf_max_user_connections;
+extern int cf_default_priority;
 
 extern char * cf_autodb_connstr;
 extern usec_t cf_autodb_idle_timeout;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -84,6 +84,7 @@ typedef struct PgStats PgStats;
 typedef union PgAddr PgAddr;
 typedef enum SocketState SocketState;
 typedef struct PktHdr PktHdr;
+typedef struct SocketPriority SocketPriority;
 
 extern int cf_sbuf_len;
 
@@ -351,6 +352,8 @@ struct PgSocket {
 
 	bool wait_sslchar:1;	/* server: waiting for ssl response: S/N */
 
+	uint16_t priority;	/* client: weight for determining position in wait queue */
+
 	int expect_rfq_count;	/* client: count of ReadyForQuery packets client should see */
 
 	usec_t connect_time;	/* when connection was made */
@@ -378,6 +381,14 @@ struct PgSocket {
 #define tmp_sk_oldfd	request_time
 #define tmp_sk_linkfd	query_start
 /* takeover_clean_socket() needs to clean those up */
+
+struct SocketPriority {
+	struct AANode tree_node;	/* used to attach user to tree */
+	char *name;		/* The application_name to be assigned priority. */
+	uint16_t priority;	/* The priority value of sockets matching name. */
+};
+
+#define DEFAULT_SOCKET_PRIORITY 1
 
 /* where the salt is temporarily stored */
 #define tmp_login_salt  cancel_key

--- a/include/loader.h
+++ b/include/loader.h
@@ -21,6 +21,8 @@ bool parse_database(void *base, const char *name, const char *connstr);
 
 bool parse_user(void *base, const char *name, const char *params);
 
+bool parse_priority(void *base, const char *name, const char *params);
+
 /* user file parsing */
 bool load_auth_file(const char *fn)  /* _MUSTCHECK */;
 bool loader_users_check(void)  /* _MUSTCHECK */;

--- a/include/objects.h
+++ b/include/objects.h
@@ -50,7 +50,7 @@ PgDatabase *register_auto_database(const char *name);
 PgUser * add_user(const char *name, const char *passwd) _MUSTCHECK;
 PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUSTCHECK;
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;
-SocketPriority *add_priority(const char *name, uint16_t value) _MUSTCHECK;
+SocketPriority *add_priority(const char *prefix_matcher, uint16_t value) _MUSTCHECK;
 
 PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;
 

--- a/include/objects.h
+++ b/include/objects.h
@@ -31,6 +31,7 @@ extern struct Slab *iobuf_cache;
 
 PgDatabase *find_database(const char *name);
 PgUser *find_user(const char *name);
+uint16_t find_priority_for_application(const char *app_name);
 PgPool *get_pool(PgDatabase *, PgUser *);
 PgSocket *compare_connections_by_time(PgSocket *lhs, PgSocket *rhs);
 bool evict_connection(PgDatabase *db)		_MUSTCHECK;
@@ -49,6 +50,7 @@ PgDatabase *register_auto_database(const char *name);
 PgUser * add_user(const char *name, const char *passwd) _MUSTCHECK;
 PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUSTCHECK;
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;
+SocketPriority *add_priority(const char *name, uint16_t value) _MUSTCHECK;
 
 PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;
 

--- a/src/client.c
+++ b/src/client.c
@@ -403,8 +403,11 @@ bool handle_auth_response(PgSocket *client, PktHdr *pkt) {
 
 static void set_appname(PgSocket *client, const char *app_name)
 {
+	uint16_t priority;
 	char buf[400], abuf[300];
 	const char *details;
+
+	priority = find_priority_for_application(app_name ? app_name : "default");
 
 	if (cf_application_name_add_host) {
 		/* give app a name */
@@ -416,9 +419,11 @@ static void set_appname(PgSocket *client, const char *app_name)
 		snprintf(buf, sizeof(buf), "%s - %s", app_name, details);
 		app_name = buf;
 	}
+
 	if (app_name) {
-		slog_debug(client, "using application_name: %s", app_name);
+		slog_debug(client, "using application_name: %s @ priority %hu", app_name, priority);
 		varcache_set(&client->vars, "application_name", app_name);
+		client->priority = priority;
 	}
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -420,11 +420,12 @@ static void set_appname(PgSocket *client, const char *app_name)
 		app_name = buf;
 	}
 
-	if (app_name) {
-		slog_debug(client, "using application_name: %s @ priority %hu", app_name, priority);
+	if (app_name)
 		varcache_set(&client->vars, "application_name", app_name);
-		client->priority = priority;
-	}
+
+	slog_debug(client, "setting priority to %hu for application_name \"%s\"",
+		priority, app_name ? app_name : "default");
+	client->priority = priority;
 }
 
 static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)

--- a/src/loader.c
+++ b/src/loader.c
@@ -617,3 +617,17 @@ bool load_auth_file(const char *fn)
 	return true;
 }
 
+bool parse_priority(void *base, const char *name, const char *params)
+{
+	SocketPriority *priority;
+	uint16_t value;
+
+	value = (uint16_t)strtol(params, NULL, 10);
+
+	priority = add_priority(name, value);
+	if (!priority)
+		log_warning("cannot create priority, no memory");
+
+	return true;
+}
+

--- a/src/main.c
+++ b/src/main.c
@@ -301,6 +301,9 @@ static const struct CfSect config_sects [] = {
 		.sect_name = "users",
 		.set_key = parse_user,
 	}, {
+		.sect_name = "priorities",
+		.set_key = parse_priority,
+	}, {
 		.sect_name = NULL,
 	}
 };

--- a/src/main.c
+++ b/src/main.c
@@ -100,6 +100,7 @@ int cf_res_pool_size;
 usec_t cf_res_pool_timeout;
 int cf_max_db_connections;
 int cf_max_user_connections;
+int cf_default_priority;
 
 char *cf_server_reset_query;
 int cf_server_reset_query_always;
@@ -225,6 +226,7 @@ CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
 CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
 CF_ABS("max_db_connections", CF_INT, cf_max_db_connections, 0, "0"),
 CF_ABS("max_user_connections", CF_INT, cf_max_user_connections, 0, "0"),
+CF_ABS("default_priority", CF_INT, cf_default_priority, 0, "10"),
 CF_ABS("syslog", CF_INT, cf_syslog, 0, "0"),
 CF_ABS("syslog_facility", CF_STR, cf_syslog_facility, 0, "daemon"),
 CF_ABS("syslog_ident", CF_STR, cf_syslog_ident, 0, "pgbouncer"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -551,7 +551,7 @@ uint16_t find_priority_for_application(const char *app_name)
 
 	node = aatree_search(&priorities_tree, (uintptr_t)app_name);
 	priority = node ? container_of(node, SocketPriority, tree_node) : NULL;
-	return priority ? priority->priority : DEFAULT_SOCKET_PRIORITY;
+	return priority ? priority->priority : cf_default_priority;
 }
 
 /* create new pool object */


### PR DESCRIPTION
_Note: I'm making this PR into our fork first so that I can get some internal testing and feedback before putting this in front of other people._

This branch adds the concept of priorities to clients in pgbouncer. Priorities are assigned based on the application_name that the client connects as. Higher priorities go in the wait list in front of lower priorities, so will be serviced first, priorities are **not** weights.

## Configuration
You can add priorities to an application by adding a new section to the config.ini like:
```
[priorities]
psql = 20
mycoolapp = 15
background_service = 10
questionable_experiment = 5
```

## Known Shortcomings
* No allowances are made for starvation, so starvation is a near certainty if high priority work is able to take up all connections continuously. Please design workloads and max connection counts accordingly when using this feature.
* The waiting list is still a list, not a priority-queue, so this is O(n) on the length of the wait list. If the target workload expects to have continuous, long, wait lines, this may be problematic.