### PR TITLE
Allow configuration of concurrent connection attempts.

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -247,7 +247,8 @@ max_concurrent_db_connection_attempts
 
 Do not allow more than this many connection attempts to be made simultaneously to
 each database. Increasing this allows pgbouncer to respond more quickly to demand
-spikes.
+spikes at the cost of more load to the server. The number of live db connections may
+temporarily exceed max_db_connections if this is increased above 1.5
 
 Default: 1
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -242,6 +242,15 @@ will immediately be opened for the waiting pool.
 
 Default: unlimited
 
+max_concurrent_db_connection_attempts
+-------------------------------------
+
+Do not allow more than this many connection attempts to be made simultaneously to
+each database. Increasing this allows pgbouncer to respond more quickly to demand
+spikes.
+
+Default: 1
+
 max_user_connections
 --------------------
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -411,6 +411,7 @@ extern int cf_min_pool_size;
 extern int cf_res_pool_size;
 extern usec_t cf_res_pool_timeout;
 extern int cf_max_db_connections;
+extern int cf_max_concurrent_db_connection_attempts;
 extern int cf_max_user_connections;
 extern int cf_default_priority;
 

--- a/src/main.c
+++ b/src/main.c
@@ -99,6 +99,7 @@ int cf_min_pool_size;
 int cf_res_pool_size;
 usec_t cf_res_pool_timeout;
 int cf_max_db_connections;
+int cf_max_concurrent_db_connection_attempts;
 int cf_max_user_connections;
 int cf_default_priority;
 
@@ -225,6 +226,7 @@ CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
 CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
 CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
 CF_ABS("max_db_connections", CF_INT, cf_max_db_connections, 0, "0"),
+CF_ABS("max_concurrent_db_connection_attempts", CF_INT, cf_max_concurrent_db_connection_attempts, 0, "1"),
 CF_ABS("max_user_connections", CF_INT, cf_max_user_connections, 0, "0"),
 CF_ABS("default_priority", CF_INT, cf_default_priority, 0, "10"),
 CF_ABS("syslog", CF_INT, cf_syslog, 0, "0"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -1150,8 +1150,8 @@ void launch_new_connection(PgPool *pool)
 	PgSocket *server;
 	int total;
 
-	/* allow only small number of connection attempts at a time */
-	if (!statlist_empty(&pool->new_server_list)) {
+	/* allow only configured number of concurrent connection attempts */
+	if (statlist_count(&pool->new_server_list) > cf_max_concurrent_db_connection_attempts) {
 		log_debug("launch_new_connection: already progress");
 		return;
 	}


### PR DESCRIPTION
This adds a the new configuration variable: `max_concurrent_db_connection_attempts`.

Using the following pgbouncer configuration:
```
max_db_connections = 1000
default_pool_size = 1000
min_pool_size = 1
max_client_conn = 1000
max_user_connections = 1000
```

With the following `pgbench` command:
```
# 1000 simultaneous clients for 5 seconds to simulate a transient load.
pgbench -c 1000 -j 8 -r -T 5 pg_bench
```
Results is ~10000 transactions handled in the 5 second period.

Adding `max_concurrent_db_connection_attempts = 20` to the configuration above results in us handling ~20000 transactions in the same period.